### PR TITLE
package: only include necessary files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 keywords = [
 	"webidl"
 ]
+include = ["src"]
 
 [badges]
 maintenance.status = "experimental"


### PR DESCRIPTION
The amount of files published to crates.io was unnecessary; this included stuff like .editorconfig, the .devcontainer/.github directories, etc. 

This reduces the compressed size from 14.4KiB to 5.8KiB (8.6KiB difference, roughly 58.7% smaller)