### PR TITLE
api: simplify identifier methods for `ExtendNonAnyType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.1.1 (Unreleased / YYYY-MM-DD)
 
 ### Breaking changes
-- `ExtendNonAnyType` trait: the function signatures of `identifier()` and `identifier_opt()` are simplified. They now take a string literal. Previously, they both took an `Identifier` type (a newtype that stores a string literal)
+- `ExtendNonAnyType` trait: the function signatures of `identifier()` and `identifier_opt()` are simplified. They now take a string literal. Previously, they both took an `Identifier` type (a newtype that stores a string literal) ([#12](https://github.com/neoncitylights/webidl-utils/pull/12))
 
 ### Features
 - Add and implement `ExtendRecordKeyType` trait for `weedle::types::RecordKeyType`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.1.1 (Unreleased / YYYY-MM-DD)
 
+### Breaking changes
+- `ExtendNonAnyType` trait: the function signatures of `identifier()` and `identifier_opt()` are simplified. They now take a string literal. Previously, they both took an `Identifier` type (a newtype that stores a string literal)
+
+### Features
 - Add and implement `ExtendRecordKeyType` trait for `weedle::types::RecordKeyType`
 
 ## 0.1.0 (2024-06-27)

--- a/src/extend/non_any.rs
+++ b/src/extend/non_any.rs
@@ -375,4 +375,9 @@ mod extend_non_any {
 
 		assert!(!NonAnyType::identifier("FooBar").is_optional());
 	}
+
+	#[test]
+	fn test_optional() {
+		assert!(NonAnyType::identifier_opt("FooBar").is_optional());
+	}
 }

--- a/src/extend/non_any.rs
+++ b/src/extend/non_any.rs
@@ -61,8 +61,8 @@ pub trait ExtendNonAnyType<'a> {
 	fn frozen_array_opt(f: FrozenArrayType<'a>) -> Self;
 	fn record(r: RecordType<'a>) -> Self;
 	fn record_opt(r: RecordType<'a>) -> Self;
-	fn identifier(i: Identifier<'a>) -> Self;
-	fn identifier_opt(i: Identifier<'a>) -> Self;
+	fn identifier(i: &'a str) -> Self;
+	fn identifier_opt(i: &'a str) -> Self;
 }
 
 impl<'a> ExtendNonAnyType<'a> for NonAnyType<'a> {
@@ -320,12 +320,12 @@ impl<'a> ExtendNonAnyType<'a> for NonAnyType<'a> {
 		Self::RecordType(MayBeNull::new_optional(r))
 	}
 
-	fn identifier(i: Identifier<'a>) -> Self {
-		Self::Identifier(MayBeNull::new_required(i))
+	fn identifier(i: &'a str) -> Self {
+		Self::Identifier(MayBeNull::new_required(Identifier(i)))
 	}
 
-	fn identifier_opt(i: Identifier<'a>) -> Self {
-		Self::Identifier(MayBeNull::new_optional(i))
+	fn identifier_opt(i: &'a str) -> Self {
+		Self::Identifier(MayBeNull::new_optional(Identifier(i)))
 	}
 }
 
@@ -335,7 +335,6 @@ mod extend_non_any {
 		ExtendFrozenArrayType, ExtendNonAnyType, ExtendRecordKeyType, ExtendRecordType,
 		ExtendSequenceType, ExtendType,
 	};
-	use weedle::common::Identifier;
 	use weedle::types::{
 		FrozenArrayType, NonAnyType, RecordKeyType, RecordType, SequenceType, Type,
 	};
@@ -374,6 +373,6 @@ mod extend_non_any {
 				.is_optional()
 		);
 
-		assert!(!NonAnyType::identifier(Identifier("FooBar")).is_optional());
+		assert!(!NonAnyType::identifier("FooBar").is_optional());
 	}
 }


### PR DESCRIPTION
`identifier()` and `identifier_opt()` now directly take a string literal. Previously, they both took an `Identifier` type (a newtype that stores a string literal)