### PR TITLE
feat: implement symbol traits for PartialNamespaceDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased (YYYY-MM-DD)
 
 ### Features
-- Implemented the traits `SymbolWithIdentifier` and `SymbolWithAttributes` for type `PartialNamespaceDefinition`.
+- Implemented the traits `SymbolWithIdentifier` and `SymbolWithAttributes` for type `PartialNamespaceDefinition`. ([#25](https://github.com/neoncitylights/webidl-utils/pull/25))
 
 ### Breaking changes
 - Fixed typo in trait names. ([#24](https://github.com/neoncitylights/webidl-utils/pull/24))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased (YYYY-MM-DD)
 
+### Features
+- Implemented the traits `SymbolWithIdentifier` and `SymbolWithAttributes` for type `PartialNamespaceDefinition`.
+
 ### Breaking changes
 - Fixed typo in trait names. ([#24](https://github.com/neoncitylights/webidl-utils/pull/24))
   - Renamed `ExtendPuncutated` to `ExtendPunctuated`.

--- a/src/symbol/with_attributes.rs
+++ b/src/symbol/with_attributes.rs
@@ -36,6 +36,7 @@ impl_symbol_with_attributes!(
 	PartialDictionaryDefinition,
 	PartialInterfaceDefinition,
 	PartialInterfaceMixinDefinition,
+	PartialNamespaceDefinition,
 	TypedefDefinition,
 	SingleArgument,
 	VariadicArgument,

--- a/src/symbol/with_identifier.rs
+++ b/src/symbol/with_identifier.rs
@@ -33,6 +33,7 @@ impl_symbol_with_identifier!(
 	PartialDictionaryDefinition,
 	PartialInterfaceDefinition,
 	PartialInterfaceMixinDefinition,
+	PartialNamespaceDefinition,
 	TypedefDefinition,
 	SingleArgument,
 	VariadicArgument,


### PR DESCRIPTION
Implements `SymbolWithIdentifier` and `SymbolWithAttributes` traits for type `PartialNamespaceDefinition`