### PR TITLE
feat: implement SymbolWithIdentifier for 2 more types again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - Implemented the traits `SymbolWithIdentifier` and `SymbolWithAttributes` for type `PartialNamespaceDefinition`. ([#25](https://github.com/neoncitylights/webidl-utils/pull/25))
+- Implemented the trait `SymbolWithIdentifier` for `ExtendedAttributeNoArgs` and `Inheritance`.
 
 ### Breaking changes
 - Fixed typo in trait names. ([#24](https://github.com/neoncitylights/webidl-utils/pull/24))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 - Implemented the traits `SymbolWithIdentifier` and `SymbolWithAttributes` for type `PartialNamespaceDefinition`. ([#25](https://github.com/neoncitylights/webidl-utils/pull/25))
-- Implemented the trait `SymbolWithIdentifier` for `ExtendedAttributeNoArgs` and `Inheritance`.
+- Implemented the trait `SymbolWithIdentifier` for `ExtendedAttributeNoArgs` and `Inheritance`. ([#27](https://github.com/neoncitylights/webidl-utils/pull/27))
 
 ### Breaking changes
 - Fixed typo in trait names. ([#24](https://github.com/neoncitylights/webidl-utils/pull/24))

--- a/src/symbol/with_identifier.rs
+++ b/src/symbol/with_identifier.rs
@@ -51,3 +51,16 @@ impl_symbol_with_identifier!(
 	AttributeNamespaceMember,
 	Inheritance,
 );
+
+#[cfg(test)]
+mod test_with_identifier {
+	use crate::symbol::SymbolWithIdentifier;
+	use weedle::attribute::ExtendedAttributeNoArgs;
+	use weedle::common::Identifier;
+
+	#[test]
+	fn test_extended_attribute_no_args() {
+		let test = ExtendedAttributeNoArgs(Identifier("FooBar"));
+		assert_eq!(test.identifier(), Identifier("FooBar"));
+	}
+}

--- a/src/symbol/with_identifier.rs
+++ b/src/symbol/with_identifier.rs
@@ -1,6 +1,7 @@
 use weedle::argument::{SingleArgument, VariadicArgument};
+use weedle::attribute::ExtendedAttributeNoArgs;
 use weedle::dictionary::DictionaryMember;
-use weedle::interface::{AttributeInterfaceMember, ConstMember};
+use weedle::interface::{AttributeInterfaceMember, ConstMember, Inheritance};
 use weedle::mixin::AttributeMixinMember;
 use weedle::namespace::AttributeNamespaceMember;
 use weedle::*;
@@ -19,6 +20,12 @@ macro_rules! impl_symbol_with_identifier {
 				}
 			}
 		)+
+	}
+}
+
+impl<'a> SymbolWithIdentifier<'a> for ExtendedAttributeNoArgs<'a> {
+	fn identifier(&self) -> weedle::common::Identifier<'a> {
+		self.0
 	}
 }
 
@@ -42,4 +49,5 @@ impl_symbol_with_identifier!(
 	AttributeInterfaceMember,
 	AttributeMixinMember,
 	AttributeNamespaceMember,
+	Inheritance,
 );

--- a/src/symbol/with_identifier.rs
+++ b/src/symbol/with_identifier.rs
@@ -11,6 +11,12 @@ pub trait SymbolWithIdentifier<'a> {
 	fn identifier(&self) -> weedle::common::Identifier<'a>;
 }
 
+impl<'a> SymbolWithIdentifier<'a> for ExtendedAttributeNoArgs<'a> {
+	fn identifier(&self) -> weedle::common::Identifier<'a> {
+		self.0
+	}
+}
+
 macro_rules! impl_symbol_with_identifier {
 	($($sym:ident),+ $(,)?) => {
 		$(
@@ -20,12 +26,6 @@ macro_rules! impl_symbol_with_identifier {
 				}
 			}
 		)+
-	}
-}
-
-impl<'a> SymbolWithIdentifier<'a> for ExtendedAttributeNoArgs<'a> {
-	fn identifier(&self) -> weedle::common::Identifier<'a> {
-		self.0
 	}
 }
 


### PR DESCRIPTION
Implements it for `ExtendedAttributeNoArgs` (tuple struct type), and `Inheritance`.